### PR TITLE
Upgrade mapbox-android-sdk to 5.5.3

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     // Mapbox SDK
     implementation 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.9'
 
-    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.4.1@aar') {
+    implementation('com.mapbox.mapboxsdk:mapbox-android-sdk:5.5.3@aar') {
         transitive=true
     }
 


### PR DESCRIPTION
Versions older than 5.5.2 suffered from a [bug](https://github.com/mapbox/mapbox-gl-native/pull/11583) that prevented Android emulators from showing the map when using hardware acceleration. This upgrades to SDK 5.5.3, the last of the 5 series, which doesn't have this issue.